### PR TITLE
Readme improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,14 +1,10 @@
 # GoCD File Based Authentication Plugin
 
-This is a file based authentication plugin which implements the GoCD [Authorization Plugin](https://plugin-api.gocd.io/current/authorization/) endpoint. This plugin allows authentication/search of users defined in a sinlge or across multiple password files.
+This is a file based authentication plugin which implements the GoCD [Authorization Plugin](https://plugin-api.gocd.io/current/authorization/) endpoint. This plugin allows authentication/search of users defined in password files.
 
 ## Building the code base
 
 To build the jar, run `./gradlew clean test assemble`
-
-## Requirements
-
-These plugins require GoCD version v17.5 or above.
 
 ## Installation
 
@@ -16,15 +12,51 @@ These plugins require GoCD version v17.5 or above.
 
 ## Usage instructions
 
-The simplest way to use this plugin is create a plain text file with the following format:
+The plugin uses the popular file format used by the `htpasswd` program:
 
-    [username]:[password hashed with SHA1 and encoded with base 64]
-    
-If your SHA1 algorithm and base 64 encoding works properly, the password "badger" should come out as "ThmbShxAtJepX80c2JY1FzOEmUk=".
+    username:hashed-password
 
-> **Note**: This is currently an insecure default, the industry standard recommendation is to use `bcrypt` or `PBKDF2` algorithm. See [#13](https://github.com/gocd/filebased-authentication-plugin/issues/13) for details.   
+The plugin currently supports passwords hashed using `bcrypt` and `SHA1`. Support for [PBKDF2](https://en.wikipedia.org/wiki/PBKDF2) is in the works. See [#13](https://github.com/gocd/filebased-authentication-plugin/issues/13) for details.
+
+> **Note**: It is highly recommended that users use passwords hashed using `bcrypt` and not `SHA1`.
 
 You can put as many username/hashed password pairs as you like -- use a new line for each one
+
+## Generating passwords using `htpasswd`
+
+You can use the [`htpasswd`](http://httpd.apache.org/docs/2.0/programs/htpasswd.html) program from Apache to manage your password file.
+
+So for example, you can use the following command to create a password file called `passwd` and put the password for the user "user" in it:
+
+```shell
+htpasswd -c [-s] [-B] passwd user
+```
+
+### htpasswd on Windows
+
+The `htpasswd` executable may be downloaded as part of the apache distribution from [Apache Haus](http://www.apachehaus.com/cgi-bin/download.plx) or [Apache Lounge](https://www.apachelounge.com/download/). Note that these executables may not work on Windows XP or Server 2003
+
+### htpasswd on Mac OSX
+
+htpasswd is already installed by default on Mac OSX.
+
+### htpasswd on Linux
+
+Debian based distributions (e.g. Ubuntu) htpasswd can be installed from the apache2-utils
+
+```shell
+$ apt-get install apache2-utils
+```
+
+### Generating passwords using python
+
+Another option is to use the following command (assumes python is installed on your system)
+
+```shell
+$ python -c "import sha; from base64 import b64encode; print b64encode(sha.new('my-password').digest())"
+```
+
+## Configuration
 
 The plugin needs to be configured to use the password file. The configuration can be added by adding a Authorization Configuration by visiting the Authorization Configuration page under *Admin > Security*.
 
@@ -61,47 +93,6 @@ Alternatively, the configuration can be added directly to the `config.xml` using
       </authConfig>
     </authConfigs>
     ```
-
-## Generating passwords using htpasswd
-
-You can use the [htpasswd](http://httpd.apache.org/docs/2.0/programs/htpasswd.html) program from Apache to manage your password file.
-
-You must use the -s option with htpasswd to force it to use SHA1 encoding for the password.
-
-So for example, you can use the following command to create a password file called "passwd" and put the password for the user "user" in it:
-
-```shell
-htpasswd -c -s passwd user
-```
-
-### htpasswd on Windows
-
-The `htpasswd` executable may be downloaded as part of the apache distribution from [Apache Haus](http://www.apachehaus.com/cgi-bin/download.plx) or [Apache Lounge](https://www.apachelounge.com/download/). Note that these executables may not work on Windows XP or Server 2003
-
-### htpasswd on Mac OSX
-
-htpasswd is already installed by default on Mac OSX.
-
-### htpasswd on Linux
-
-Debian based distributions (e.g. Ubuntu) htpasswd can be installed from the apache2-utils
-
-```shell
-$ apt-get install apache2-utils
-```
-
-### Generating passwords using python
-
-Another option is to use the following command (assumes python is installed on your system)
-
-```shell
-$ python -c "import sha; from base64 import b64encode; print b64encode(sha.new('my-password').digest())"
-```
-
-## Limitations
-
-This plugin is a as-is replacement for GoCD support for file based authentication. SHA1 is considered insecure and not recommended.
-A file based [strong auth plugin](https://github.com/danielsomerfield/go-strong-auth-plugin#go-strong-auth-plugin) was built using the deprecated Authentication endpoints, any contributions towards building a secure file based plugin would be appreciated.
 
 ## Troubleshooting
 


### PR DESCRIPTION
* removed "Requirements" section, since it does not apply anymore
* removed "Limitations" section, since it does not apply anymore
* added sufficient clarifications around bcrypt and warnings about not
  using SHA1
* moved the "Generating passwords using htpasswd" before the XML
  configuration